### PR TITLE
Get Throughput to all interface, with thresholds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,9 @@ crashlytics-build.properties
 fabric.properties
 
 *.log
+
+# Virtualenv
+include/
+local/
+share/
+.cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,18 @@
 language: python
-python: 3.5
+python: 3.6
 
-env:
-  - TOXENV=py35
-  - TOXENV=py34
-  - TOXENV=py33
-  - TOXENV=py27
-  - TOXENV=pypy
+matrix:
+  include:
+  - python: "3.6"
+    env: TOXENV=py36
+  - python: "3.5"
+    env: TOXENV=py35
+  - python: "3.4"
+    env: TOXENV=py34
+  - python: "2.7"
+    env: TOXENV=py27
+  - python: "pypy"
+    env: "TOXENV=pypy"
 
 install: pip install -U tox
 

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,3 +11,4 @@ Contributors
 ------------
 
 * Thomas Fischer <mail@se-di.de>
+* Rémi Verchère <remi@verchere.fr>

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -104,6 +104,6 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.6, 2.7, 3.3, and 3.4, and for PyPy. Check
-   https://travis-ci.org/ralph-hm/nagios_check_paloalto/pull_requests
+3. The pull request should work for Python 2.7, 3.4, 3.5 and 3.6 and for PyPy.
+   Check https://travis-ci.org/ralph-hm/nagios_check_paloalto/pull_requests
    and make sure that the tests pass for all supported Python versions.

--- a/check_pa/check_paloalto.py
+++ b/check_pa/check_paloalto.py
@@ -152,6 +152,14 @@ def parse_args(args):
         nargs='?',
         required=True,
     )
+    parser_throughput.add_argument(
+        '-w', '--warn',
+        metavar='WARN', type=int, default=8000000000,
+        help='Warning if throughput is greater. In bps (default: %(default)s)')
+    parser_throughput.add_argument(
+        '-c', '--crit',
+        metavar='CRIT', type=int, default=9000000000,
+        help='Critical if throughput is greater. In bps (default: %(default)s)')
     parser_throughput.set_defaults(func=throughput)
 
     return parser.parse_args(args)

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -150,6 +150,7 @@ usage::
       -h, --help            show this help message and exit
       -i [INTERFACE], --interface [INTERFACE]
                             PA interface name, seperate by comma.
+                            if interface name is 'all', every interface throughput will be requested
 
 example::
 
@@ -157,6 +158,9 @@ example::
     $ THROUGHPUT OK - Input is 5.74 Mb/s - Output is 11.81 Mb/s | 'in_bps_ethernet1/1'=5743432.0;;;0 'out_bps_ethernet1/1'=11807524.0;;;0
 
     $ check_paloalto -H HOST -T TOKEN throughput -i ethernet1/1,ethernet1/2
+    $ THROUGHPUT OK - Input is 44.12 Mb/s - Output is 24.59 Mb/s | 'in_bps_ethernet1/1'=5895616.0;;;0 'in_bps_ethernet1/2'=38225768.0;;;0 'out_bps_ethernet1/1'=15926620.0;;;0 'out_bps_ethernet1/2'=8661100.0;;;0
+
+    $ check_paloalto -H HOST -T TOKEN throughput -i all
     $ THROUGHPUT OK - Input is 44.12 Mb/s - Output is 24.59 Mb/s | 'in_bps_ethernet1/1'=5895616.0;;;0 'in_bps_ethernet1/2'=38225768.0;;;0 'out_bps_ethernet1/1'=15926620.0;;;0 'out_bps_ethernet1/2'=8661100.0;;;0
 
 To get all available names of your interfaces, please have a look at

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ test_requirements = [
 ]
 
 setup(name='check_paloalto',
-      version='0.3.2',
+      version='0.3.3',
       description="check_paloalto is a Nagios/Icinga plugin for Palo Alto Next Generation Firewalls. It is written in "
                   "Python and based on the PA REST API.",
       long_description=readme + '\n\n' + history,

--- a/tests/test_throughput.py
+++ b/tests/test_throughput.py
@@ -26,6 +26,8 @@ class TestThroughput(object):
 
     @responses.activate
     def test_with_three_interfaces(self, statefile):
+        self.warn = 8000000000
+        self.crit = 9000000000
         self.interface = 'ethernet1/1, ethernet1/2, ethernet1/3'
         interfaces = []
         for interface in self.interface.split(','):
@@ -100,6 +102,8 @@ class TestThroughput(object):
     def test_with_one_interface(self, statefile):
         file1 = 'throughput1.xml'
 
+        self.warn = 8000000000
+        self.crit = 9000000000
         self.interface = 'ethernet1/1'
         interfaces = []
         for interface in self.interface.split(','):
@@ -175,10 +179,14 @@ class TestThroughput(object):
         pa_1 = self.__class__()
         pa_1.host = "192.168.0.1"
         pa_1.interface = "ethernet1/1"
+        pa_1.warn = 8000000000
+        pa_1.crit = 9000000000
 
         pa_2 = self.__class__()
         pa_2.host = "192.168.0.2"
         pa_2.interface = "ethernet1/1"
+        pa_2.warn = 8000000000
+        pa_2.crit = 9000000000
 
         from nagiosplugin import Cookie
 
@@ -217,6 +225,8 @@ class TestThroughput(object):
     def test_new_input_less_than_old(self, statefile):
         file1 = 'throughput1.xml'
 
+        self.warn = 8000000000
+        self.crit = 9000000000
         self.interface = 'ethernet1/1'
         interfaces = []
         for interface in self.interface.split(','):
@@ -263,6 +273,8 @@ class TestThroughput(object):
     def test_new_output_less_than_old(self, statefile):
         file1 = 'throughput1.xml'
 
+        self.warn = 8000000000
+        self.crit = 9000000000
         self.interface = 'ethernet1/1'
         interfaces = []
         for interface in self.interface.split(','):
@@ -318,6 +330,8 @@ class TestThroughput(object):
     def test_same_time(self, statefile):
         file1 = 'throughput1.xml'
 
+        self.warn = 8000000000
+        self.crit = 9000000000
         self.interface = 'ethernet1/1'
         interfaces = []
         for interface in self.interface.split(','):
@@ -367,6 +381,8 @@ class TestThroughput(object):
     def test_api_failed(self, statefile):
         file1 = 'throughput1.xml'
 
+        self.warn = 8000000000
+        self.crit = 9000000000
         self.interface = 'ethernet1/1'
         interfaces = []
         for interface in self.interface.split(','):


### PR DESCRIPTION
Two enhancements:

* Add 'all' interfaces. When using the `-i all` args to throughput, check will ist all available interfaces and loop to get all values
* Add warning + critical throughput threshold (by default warning 8gbps / 9gbps as one consider Palo Alto has 10Gbps interfaces).